### PR TITLE
Use hatanaka and ncompress for decompression

### DIFF
--- a/scripts/conda_gn37.yaml
+++ b/scripts/conda_gn37.yaml
@@ -19,5 +19,6 @@ dependencies:
   - pip:
     - georinex
     - p_tqdm #useful for long processing sessions
-    - git+https://github.com/bmatv/python-unlzw.git # memory leak patched
+    - hatanaka
+    - ncompress
 

--- a/scripts/gn_lib/gn_io/common.py
+++ b/scripts/gn_lib/gn_io/common.py
@@ -1,14 +1,11 @@
 '''Base functions for file reading'''
 import gzip
-import unlzw
+import ncompress
 
 def _lzw2bytes(path):
-    '''Decompresses .Z file and outputs the content.
-    Memory leak corrected in the github repo v0.1.2'''
+    '''Decompresses .Z file and outputs the content.'''
     with open(path,'rb') as lzw_file:
-        lzw_compressed = lzw_file.read()
-    databytes = unlzw.unlzw(lzw_compressed)
-    del lzw_compressed
+        databytes = ncompress.decompress(lzw_file)
     return databytes
 
 def _gz2bytes(path):


### PR DESCRIPTION
Hi! This PR makes use of the [hatanaka](https://github.com/valgur/hatanaka) and [ncompress](https://github.com/valgur/ncompress) libraries for a more streamlined and robust decompression of downloaded RINEX products.
Both are available from PyPI and support all operating systems and reasonably recent Python 3 versions. 