### PR TITLE
README improvements for first time users

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,58 @@ The software consists of three main components:
 * Precise Orbit Determination (POD), and
 * Various scripts for combination and analysis of solutions
 
+
+## Getting started
+
+You can quickly download a ready-to-run Ginan environment using docker by running:
+
+    mkdir ginan-data
+    docker run -it -v ginan-data:/data gnssanalysis/ginan:v3.0.0 bash
+
+This command connects the `ginan-data` directory on the host (your pc), with the `/data` directory in the container, to allow file access between the two systems, and opens a command line (`bash`) for executing commands.
+
+You will need to have [docker](https://docs.docker.com/get-docker/) installed to use this method.
+
+To verify you have the Ginan executables available once at the Ginan command line, run:
+
+    pea --help
+
+
+### Download example dependencies
+
+Download all of the example data using the scripts and filelists provided. From `/ginan`:
+
+```bash
+cd inputData/data
+./getData.sh
+cd ../products
+./getProducts.sh
+```
+
+### Ready!
+
+Congratulations! You are now ready to trial the examples from the `exampleConfigs` directory. See Ginan's manual for detailed explanation of each example. Note that examples have relative paths to files in them and rely on the presence of `products` and `data` directories inside the `inputData` directory.
+
+The paths are relative to the `exampleConfigs` directory and hence all the examples must be run from the `exampleConfigs` directory.
+
+To run the first example of the PEA:
+
+```bash
+cd /ginan/exampleConfigs
+pea --config ppp_example.yaml
+```
+
+This should create `outputs/ppp_example` directory with various `*.trace` files, which contain details about stations processing, a `Network*.trace` file, which contains the results of Kalman filtering, and other auxiliary output files as configured in the yamls.
+
+
+### Python tools
+
+We use Python for automated process (download), postprocessing and visualisation. To use the developed tools, we recommrnd to use a virtual environment (or Anaconda equivalent). A requirements file is available in the `scripts/` directory and can be run via
+
+```python
+pip3 install -r requirements.txt
+```
+
 ## Using Ginan with an AppImage
 
 You can quickly download a precompiled binary of Ginan's pea from the `develop-weekly-appimage` branch of github.
@@ -51,22 +103,8 @@ or on windows:
     ginan/Ginan-x86_64.AppImage
 
 
-## Using Ginan with Docker
+## Installing from source
 
-You can quickly download a ready-to-run Ginan environment using docker by running:
-
-    docker run -it -v ${host_data_folder}:/data gnssanalysis/ginan:v3.0.0 bash
-
-This command connects the `${host_data_folder}` directory on the host (your pc), with the `/data` directory in the container, to allow file access between the two systems, and opens a command line (`bash`) for executing commands.
-
-You will need to have [docker](https://docs.docker.com/get-docker/) installed to use this method.
-
-To verify you have the Ginan executables available once at the Ginan command line, run:
-
-    pea --help
-
-
-## Installation from source
 ### Supported Platforms
 
 Ginan is supported and tested on the following platforms
@@ -97,14 +135,8 @@ If using gcc verion 11 or about, the minimum version of libraries are:
 
 Scripts to install dependencies for Ubuntu 18.04/20.04, 22.04, Fedora 38 are available on the `scripts/installation` directory. Users on other system might need to have a look at the `scripts/installation/generic.md` file, which contains the major steps.
 
-### Python
-
-We use Python for automated process (download), postprocessing and visualisation. To use the developed tools, we recommand to use a virtual-environement (or Anaconda equivalent). A requirements file is available in the `scripts/` directory and can be run via
-```python
-pip3 install -r requirements.txt
-```
-
 ### Build
+
 Prepare a directory to build in - it's better practice to keep this separated from the source code.
 From the Ginan git root directory:
 
@@ -225,33 +257,8 @@ The documentation can then be found at `Docs/codeDocs/index.html`.
 Note that documentation is also generated automatically if `make` is called without arguments and `doxygen` and `graphviz` dependencies are satisfied.
 
 
-## Ready!
-Congratulations! You are now ready to trial the examples from the `exampleConfigs` directory. See Ginan's manual for detailed explanation of each example. Note that examples have relative paths to files in them and rely on the presence of `products` and `data` directories inside the `inputData` directory. Make sure you've run `s3_filehandler.py` from the Build step of these instructions.
+### Acknowledgements
 
-The paths are relative to the `exampleConfigs` directory and hence all the examples must be run from the `exampleConfigs` directory.
-
-NB: Examples may be configured to use mongoDB. If you have not installed it, please set `mongo: enable` to false in the pea config files.
-
-To run the first example of the PEA:
-
-```bash
-cd ../exampleConfigs
-
-../bin/pea --config ppp_example.yaml
-```
-
-This should create `outputs/ppp_example` directory with various `*.trace` files, which contain details about stations processing, a `Network*.trace` file, which contains the results of Kalman filtering, and other auxiliary output files as configured in the yamls.
-
-You can remove the need for path specification to the executable by using the symlink within `exampleConfigs`, or by adding Ginan's bin directory to `~/.bashrc` file:
-```
-PATH="path_to_ginan_bin:$PATH"
-```
-
-## Scripts
-In addition to the Ginan binaries, [scripts](scripts.index) are available to assist with downloading input files, and viewing and comparing generated outputs.
-
-
-### Acknowledgements:
 We have used routines obtained from RTKLIB, released under a BSD-2 license, these routines have been preserved with modifications in the folder `cpp/src/rtklib`. The original source code from RTKLib can be obtained from https://github.com/tomojitakasu/RTKLIB.
 
 We have used routines obtained from Better Enums, released under the BSD-2 license, these routines have been preserved in the folder `cpp/src/3rdparty` The original source code from Better Enums can be obtained from http://github.com/aantron/better-enums.

--- a/exampleConfigs/fit_sp3_pseudoobs.yaml
+++ b/exampleConfigs/fit_sp3_pseudoobs.yaml
@@ -181,7 +181,7 @@ estimation_parameters:
 
 
 mongo:
-    enable:                         primary
+    enable:                         none
     primary_database:               <CONFIG>
     output_measurements:            primary
     output_states:                  primary

--- a/exampleConfigs/pod_example.yaml
+++ b/exampleConfigs/pod_example.yaml
@@ -473,7 +473,7 @@ estimation_parameters:
 
 
 mongo:
-    enable:                     primary
+    enable:                     none
     #enable:                     none
     output_components:          primary
     output_states:              primary

--- a/exampleConfigs/ppp_example.yaml
+++ b/exampleConfigs/ppp_example.yaml
@@ -278,7 +278,7 @@ estimation_parameters:
 
 
 mongo:                   # Mongo is a database used to store results and intermediate values for later analysis and inter-process communication
-    enable:              primary                     # Enable and connect to mongo database {none,primary,secondary,both}
+    enable:              none                     # Enable and connect to mongo database {none,primary,secondary,both}
     primary_uri:         mongodb://localhost:27017   # Location and port of the mongo database to connect to
     primary_database:    <CONFIG>
     primary_suffix:      ""                          # Suffix to append to database elements to make distinctions between runs for comparison

--- a/exampleConfigs/record_snr.yaml
+++ b/exampleConfigs/record_snr.yaml
@@ -43,7 +43,7 @@ processing_options:
         process: true
     
 mongo:
-  enable: primary
+  enable: none
   output_trace: primary
   output_config: primary
   primary_uri: "mongodb://localhost:27017"

--- a/exampleConfigs/rt_ppp_example.yaml
+++ b/exampleConfigs/rt_ppp_example.yaml
@@ -185,7 +185,7 @@ estimation_parameters:
 
 mongo:                   # Mongo is a database used to store results and intermediate values for later analysis and inter-process communication
 
-    enable:              primary                     # Enable and connect to mongo database {none,primary,secondary,both}
+    enable:              none                     # Enable and connect to mongo database {none,primary,secondary,both}
     primary_uri:         mongodb://localhost:27017   # Location and port of the mongo database to connect to
     primary_database:    <CONFIG>
     output_components:   primary                     # Output components of measurements {none,primary,secondary,both}


### PR DESCRIPTION
I went through the README from scratch on a Windows machine to check if the order of the instructions made sense. This PR is proposing to reorder parts of the README so that everything that a first time user needs to get ginan running is in one spot.

* Getting started with Docker has been moved to the top. The AppImage is simple to use, but it does not have any example data so it's not easy for a user to run ginan for the first time.
* `mkdir ginan-data` has been added in the docker instructions so that a user does not encounter an error that ${host_data_folder} does not exist
* The downloads with getData.sh and getProducts.sh have been moved up to the Getting Started section from the Build section
* Ready! section has been moved to Getting Started
* Python tools instructions has been moved to the Getting Started section instead of Installation from source section
* Mongodb has been disabled in all examples, because it's unlikely that a first time user will have mongodb running, and it's just another option that they're going to have to find and turn off