### PR TITLE
Add \n to SOLUTION/EPOCHS output in sinex file

### DIFF
--- a/src/cpp/common/sinex.cpp
+++ b/src/cpp/common/sinex.cpp
@@ -1705,7 +1705,7 @@ void write_snx_epochs(
 
 	for (auto& [id, sst] : theSinex.solEpochMap)
 	{
-		tracepdeex(0, out, " %4s %2s %4s %c %2.2d:%3.3d:%5.5d %2.2d:%3.3d:%5.5d %2.2d:%3.3d:%5.5d",
+		tracepdeex(0, out, " %4s %2s %4s %c %2.2d:%3.3d:%5.5d %2.2d:%3.3d:%5.5d %2.2d:%3.3d:%5.5d\n",
 					sst.sitecode.c_str(),
 					sst.ptcode	.c_str(),
 					sst.solnnum	.c_str(),


### PR DESCRIPTION
Without the newline char, the terminating "-SOLUTION/EPOCHS" ends up in the last epoch line, rather than a line of its own. This causes parsing to fail when importing with DynAdjust. With the addition of the newline char, DynAdjust is able to parse the sinex file without issue.

**Before:**

```
+SOLUTION/EPOCHS
 R591  A    0 -24: 63:84042 24: 64:84042 24: 64:40842-SOLUTION/EPOCHS
```

**After:**

```
+SOLUTION/EPOCHS
 R591  A    0 - 24: 63:84042 24: 64:84042 24: 64:40842
-SOLUTION/EPOCHS
```

