### PR TITLE
Change PDE cycle slip block datetime from week sec format to YYYY-MM-DD HH:MM:SS.ss

### DIFF
--- a/src/cpp/common/acsQC.cpp
+++ b/src/cpp/common/acsQC.cpp
@@ -489,8 +489,7 @@ void cycleslip2(
     GObs&    obs       ///< Navigation object for this satellite
 )
 {
-    GWeek week = lcBase.time;
-    GTow  tow  = lcBase.time;
+    string timeStr = lcBase.time.to_string(2);
 
     auto& recOpts = acsConfig.getRecOpts(obs.mount);
 
@@ -574,10 +573,9 @@ void cycleslip2(
     tracepdeex(
         2,
         trace,
-        "\nPDE-CS GPST DUAL  %4d %8.1f %4s %5.2f %5.3f %8.4f %7.4f %8.4f                           "
+        "\nPDE-CS GPST DUAL  %s %4s %5.2f %5.3f %8.4f %7.4f %8.4f                           "
         "     ",
-        week,
-        tow,
+        timeStr.c_str(),
         lcBase.Sat.id().c_str(),
         satStat.el * R2D,
         lamw,
@@ -610,8 +608,7 @@ void cycleslip3(
     GObs&    obs       ///< Navigation object for this satellite
 )
 {
-    GWeek week = lc.time;
-    GTow  tow  = lc.time;
+    string timeStr = lc.time.to_string(2);
 
     auto& recOpts = acsConfig.getRecOpts(obs.mount);
 
@@ -721,9 +718,8 @@ void cycleslip3(
     tracepdeex(
         2,
         trace,
-        "\nPDE-CS GPST TRIP  %4d %8.1f %4s %5.2f %5.3f %8.4f %7.4f %8.4f        %6.2f %8.4f %7.4f ",
-        week,
-        tow,
+        "\nPDE-CS GPST TRIP  %s %4s %5.2f %5.3f %8.4f %7.4f %8.4f        %6.2f %8.4f %7.4f ",
+        timeStr.c_str(),
         lc.Sat.id().c_str(),
         satStat.el * R2D,
         lamw,
@@ -766,8 +762,7 @@ void detectslip(
     char id[32];
     lc_new.Sat.getId(id);
 
-    GWeek week = lc_new.time;
-    GTow  tow  = lc_new.time;
+    string timeStr = lc_new.time.to_string(2);
 
     auto& recOpts = acsConfig.getRecOpts(obs.mount);
 
@@ -794,9 +789,8 @@ void detectslip(
             tracepdeex(
                 1,
                 trace,
-                "\nPDE-CS GPST       %4d %8.1f %4s %5.2f --time gap --",
-                week,
-                tow,
+                "\nPDE-CS GPST       %s %4s %5.2f --time gap --",
+                timeStr.c_str(),
                 id,
                 satStat.el * R2D
             );
@@ -804,9 +798,8 @@ void detectslip(
             tracepdeex(
                 1,
                 trace,
-                "\nPDE-CS GPST       %4d %8.1f %4s %5.2f --low_elevation --",
-                week,
-                tow,
+                "\nPDE-CS GPST       %s %4s %5.2f --low_elevation --",
+                timeStr.c_str(),
                 id,
                 satStat.el * R2D
             );
@@ -814,9 +807,8 @@ void detectslip(
             tracepdeex(
                 1,
                 trace,
-                "\nPDE-CS GPST       %4d %8.1f %4s %5.2f --satStat.lc_pre.time.time --",
-                week,
-                tow,
+                "\nPDE-CS GPST       %s %4s %5.2f --satStat.lc_pre.time.time --",
+                timeStr.c_str(),
                 id,
                 satStat.el * R2D
             );
@@ -911,9 +903,8 @@ void detectslip(
         tracepdeex(
             1,
             trace,
-            "\nPDE-CS GPST       %4d %8.1f %4s %5.2f --  re-tracking   --\n",
-            week,
-            tow,
+            "\nPDE-CS GPST       %s %4s %5.2f --  re-tracking   --\n",
+            timeStr.c_str(),
             id,
             satStat.el * R2D
         );
@@ -931,9 +922,8 @@ void detectslip(
         tracepdeex(
             1,
             trace,
-            "\nPDE-CS GPST       %4d %8.1f %4s %5.2f --single frequency--\n",
-            week,
-            tow,
+            "\nPDE-CS GPST       %s %4s %5.2f --single frequency--\n",
+            timeStr.c_str(),
             id,
             satStat.el * R2D
         );
@@ -983,7 +973,7 @@ void detectslips(
     tracepdeex(
         2,
         trace,
-        "\nPDE-CS GPST       week      sec  prn   el   lamw     gf12    mw12    siggf  sigmw  "
+        "\nPDE-CS GPST       epoch                  prn  el   lamw     gf12    mw12    siggf  sigmw  "
         "lamew     gf25    mw25   "
         "            LC                   N1   N2   N5\n"
     );


### PR DESCRIPTION
In `PDE cycle slip detection & repair` block in station trace, change from `week` and `sec` to epoch in datetime format. This makes it consistent with epoch output in network trace which makes it easier to grep and work with the files.

Example output below:

```
PDE-CS GPST       epoch                  prn  el   lamw     gf12    mw12    siggf  sigmw  lamew     gf25    mw25               LC                   N1   N2   N5

PDE-CS GPST DUAL  2025-10-05 22:21:30.00  G19 59.90 0.862   0.0098  0.0385   0.0069                                     vtpv=     0.0 val=     0.0 thres=  5.43    5    2
```
