### PR TITLE
Release v4.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
+# [4.1.3] 2026-08-19
+
+## Added
+
+Ginan core:
+- Added configurable preprocessor frequency selection, allowing more flexible code/frequency priorities in preprocessing workflows.
+- Added a Doppler placeholder path in the preprocessor to support upcoming Doppler-based preprocessing work.
+
+## Changed
+
+Ginan core:
+- Updated broadcast ephemeris IODE selection to support use of the latest suitable ephemeris/IODE in real-time processing.
+- Added a safeguard to wait at least 30 seconds before changing IODE when uploading SSR streams.
+
+## Fixed
+
+Ginan core:
+- Fixed RINEX time parsing when `str2time` reads overflowing fixed-width fields.
+
 # [4.1.2] 2026-06-16
 
 ## Added

--- a/Docs/announcements.md
+++ b/Docs/announcements.md
@@ -1,58 +1,11 @@
-
-> **13 Feb 2026** - the Ginan team is pleased to release Ginan patch v4.1.1
->
-> **Highlights**:
-> 
-> * Fix issue reading RINEX files in Windows binaries (CRLF-ended format)
-> * Allow station / receivers names to start with a number in config (e.g. 4RMA00AUS)
-> * Introduce reading of GLONASS satellites for RNX2 files
-> * Various updates to the GUI:
->   * Apriori position as config option in interface
->   * Ability to run faster rate clocks (1 Hz -> 100 Hz)
->   * SINEX downloading and validation
->   * Verify downloads against CDDIS checksums 
->   * Use archived products if available
-
-> **30 Jan 2026** - the Ginan team is pleased to release Ginan update v4.1.0
+> **19 Aug 2026** - the Ginan team is pleased to release Ginan patch v4.1.3
 >
 > **Highlights**:
 >
-> * Introduction of SouthPAN SBAS capabilities into Ginan:
->   * Choice of running L1 SBAS, DFMC (dual-frequency multi-constellation) and PVS (Precise Point Positioning Via SouthPAN)
->   * Includes SBF (Septentrio) input
->   * Included sanity check configurations for SBAS, DFMC and PVS
-> * Additions to the Graphical User Interface (GUI) for Ginan - GinanUI:
->   * "Constellations" config tab for managing code priorities for the selected PPP provider/series/project
->   * Support for downloading products from the REPRO3 directory for older RINEX files
->   * Detection of supported code priorities for PPP products using the corresponding .BIA file
->   * Verification of PPP product constellations using the corresponding .SP3 file
->
-
-> **16 Dec 2025** - the Ginan team is pleased to release v4.0.0 of the toolkit.
->
-> **Main Highlights**:
->
-> * Introduce Ginan binaries for Linux, MacOS and Windows
->   * The binaries can be found on the GitHub website:
->     * [Ginan Binaries](https://github.com/GeoscienceAustralia/ginan/releases/tag/v4.0.0)
-> * Introduce a Qt-based Graphical User Interface (GUI) for Ginan:
->   * Simply open RNX file and choose from drop-downs
->   * Download the GUI from GitHub release page
->   * Works across Linux, MacOS and Windows
->   * Built using PySide 6
->   * A user manual for the GUI can be found here:
->     * [Ginan GUI User Manual](https://github.com/GeoscienceAustralia/ginan/tree/main/scripts/GinanUI/docs/USER_GUIDE.md)
->
-> ![GinanGUI Screenshot](images/GinanGUI-screenshot.png)
-> *A screenshot of the Ginan GUI in action.* 
->
-> **Major Changes**:
->
-> * Major refactor: use OpenBLAS / LAPACK instead of Eigen
->   * Refactored RTS code
->   * Refactored core Kalman filter code
->   * Improved efficiency (up to 30% faster on network runs)
-> * Major improvement in handling state errors in pre-fit and post-fit outlier screening
-> * Move to vcpkg as the primary package manager for Ginan
-> * Add RNX2 --> RNX3 phase signal mapping in config
->
+> * Fixed RINEX time parsing when `str2time` reads overflowing fixed-width fields
+> * Added configurable preprocessor frequency selection for more flexible code/frequency priorities
+> * Updated broadcast ephemeris IODE selection to support use of the latest suitable ephemeris/IODE in real-time processing
+> * Added a safeguard to wait at least 30 seconds before changing IODE when uploading SSR streams
+> * Added a Doppler placeholder path in the preprocessor to support upcoming Doppler-based preprocessing work
+> * The binaries can be found on the GitHub website:
+>   * [Ginan v4.1.3 Binaries](https://github.com/GeoscienceAustralia/ginan/releases/tag/v4.1.3)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Ginan: GNSS Analysis Software Toolkit
 
-[![Version](https://img.shields.io/badge/version-v4.1.2-blue.svg)](https://github.com/GeoscienceAustralia/ginan/releases)
+[![Version](https://img.shields.io/badge/version-v4.1.3-blue.svg)](https://github.com/GeoscienceAustralia/ginan/releases)
 [![License](https://img.shields.io/badge/license-Apache--2.0-green.svg)](LICENSE.md)
 [![Platform](https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey.svg)](#supported-platforms)
 [![Docker](https://img.shields.io/badge/docker-available-blue.svg)](https://hub.docker.com/r/gnssanalysis/ginan)
@@ -56,7 +56,7 @@ The fastest way to get started with Ginan is using Docker:
 
 ```bash
 # Pull and run the latest Ginan container
-docker run -it -v "$(pwd):/data" gnssanalysis/ginan:v4.1.2 bash
+docker run -it -v "$(pwd):/data" gnssanalysis/ginan:v4.1.3 bash
 
 # Verify installation
 pea --help
@@ -128,10 +128,10 @@ Prerequisite: install [Docker](https://docs.docker.com/get-docker/).
 
 ```bash
 # Run Ginan container with data volume mounting on Linux/macOS
-docker run -it -v "$(pwd):/data" gnssanalysis/ginan:v4.1.2 bash
+docker run -it -v "$(pwd):/data" gnssanalysis/ginan:v4.1.3 bash
 
 # PowerShell equivalent on Windows
-docker run -it -v "${PWD}:/data" gnssanalysis/ginan:v4.1.2 bash
+docker run -it -v "${PWD}:/data" gnssanalysis/ginan:v4.1.3 bash
 ```
 
 The command mounts your current directory to `/data` in the container and opens an interactive shell with Ginan available.
@@ -304,7 +304,7 @@ cd ../../exampleConfigs
 
 Expected output:
 ```
-PEA starting... (main ginan-v4.1.2 from ...)
+PEA starting... (main ginan-v4.1.3 from ...)
 Options:
   -h [ --help ]     Help
   -q [ --quiet ]    Less output
@@ -473,4 +473,4 @@ All incorporated code has been preserved with appropriate modifications in the `
 
 ---
 
-**Developed by [Geoscience Australia](https://www.ga.gov.au/)** | **Version 4.1.2** | **[GitHub Repository](https://github.com/GeoscienceAustralia/ginan)**
+**Developed by [Geoscience Australia](https://www.ga.gov.au/)** | **Version 4.1.3** | **[GitHub Repository](https://github.com/GeoscienceAustralia/ginan)**

--- a/src/CMakePresets.json
+++ b/src/CMakePresets.json
@@ -54,7 +54,7 @@
         "rhs": "Darwin"
       },
       "cacheVariables": {
-        "BLA_VENDOR": "OpenBLAS"
+        "BLA_VENDOR": "Apple"
       }
     },
     {
@@ -64,7 +64,6 @@
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "arm64-osx",
         "CMAKE_OSX_ARCHITECTURES": "arm64",
-        "OpenBLAS_DIR": "/opt/homebrew/opt/openblas/lib/cmake/openblas",
         "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/cmake/toolchain/clang_mac_arm64.cmake",
         "VCPKG_INSTALLED_DIR": "${sourceDir}/../vcpkg_installed/macos-arm64"
       }
@@ -76,7 +75,6 @@
       "cacheVariables": {
         "VCPKG_TARGET_TRIPLET": "x64-osx",
         "CMAKE_OSX_ARCHITECTURES": "x86_64",
-        "OpenBLAS_DIR": "/usr/local/opt/openblas/lib/cmake/openblas",
         "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/cmake/toolchain/clang_mac_x64.cmake",
         "VCPKG_INSTALLED_DIR": "${sourceDir}/../vcpkg_installed/macos-x64"
       }

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(pea
 		common/api.cpp
 		common/ntripBroadcast.cpp
 		common/acsQC.cpp
+		common/preprocessorFreqs.cpp
 		common/algebra.cpp
 		common/algebra_old.cpp
 		common/algebraTrace.cpp

--- a/src/cpp/common/acsConfig.cpp
+++ b/src/cpp/common/acsConfig.cpp
@@ -4579,7 +4579,7 @@ bool ACSConfig::parse(
     for (E_Sys sys : magic_enum::enum_values<E_Sys>())
     {
         code_priorities[sys] = default_code_priorities;
-        eph_time_delay[sys]  = default_eph_time_delay[sys];
+        eph_time_delay[sys]  = 0;
     }
 
     vector<string> yamlList;
@@ -6972,8 +6972,7 @@ bool ACSConfig::parse(
                         eph_time_delay[sys],
                         sys_options,
                         {"@ eph_time_delay"},
-                        "Time delay for Broadcast Ephmeris when simulating real-time in "
-                        "post-process"
+                        "Time delay before switching to next broadcast ephemeris when IODE changes"
                     );
                 }
             }

--- a/src/cpp/common/acsConfig.hpp
+++ b/src/cpp/common/acsConfig.hpp
@@ -658,15 +658,6 @@ struct GlobalOptions
     map<E_Sys, string> constrain_phase_bias;
 
     map<E_Sys, double> eph_time_delay;
-    map<E_Sys, double> default_eph_time_delay = {
-        {E_Sys::GPS, -7200.0},
-        {E_Sys::GLO, 0.0},
-        {E_Sys::GAL, 0.0},
-        {E_Sys::QZS, 0.0},
-        {E_Sys::BDS, 0.0},
-        {E_Sys::LEO, 0.0},
-        {E_Sys::SBS, 0.0}
-    };
 
     bool common_sat_pco       = false;
     bool common_rec_pco       = false;

--- a/src/cpp/common/acsQC.cpp
+++ b/src/cpp/common/acsQC.cpp
@@ -1,13 +1,13 @@
 // #pragma GCC optimize ("O0")
 
 #include "common/acsQC.hpp"
+#include <array>
 #include <cmath>
 #include <iostream>
 #include <vector>
 #include "common/acsConfig.hpp"
 #include "common/algebra.hpp"
 #include "common/common.hpp"
-#include "common/constants.hpp"
 #include "common/enums.h"
 #include "common/navigation.hpp"
 #include "common/observations.hpp"
@@ -155,147 +155,6 @@ double lomThreshold(int dof)
         return 0;
 
     return chisqr_arr[dof - 1] / dof;
-}
-
-/** Select up to three configured frequency bands for a satellite system.
- *
- * This is the legacy frequency selector used by several modelling paths outside
- * slip detection.  It follows `acsConfig.code_priorities[sys]` and converts the
- * first unique codes into frequency bands, but it does not inspect a particular
- * observation to confirm that measurements are present.
- *
- * The outputs retain historical defaults (`F1`, `F2`, `F5`) when priorities are
- * incomplete.  Do not use this helper when the algorithm must know which
- * frequencies are actually observed at the current epoch; use `obsFreqs()` for
- * slip detection.
- *
- * @param[in]  sys Satellite system.
- * @param[out] ft1 First configured frequency band.
- * @param[out] ft2 Second configured frequency band.
- * @param[out] ft3 Third configured frequency band.
- *
- * @return false only when no code priorities exist for `sys`; true otherwise.
- */
-bool satFreqs(E_Sys sys, E_FType& ft1, E_FType& ft2, E_FType& ft3)
-{
-    bool ft1Ready = false;
-    bool ft2Ready = false;
-
-    ft1 = F1;
-    ft2 = F2;
-    ft3 = F5;
-
-    if (acsConfig.code_priorities.find(sys) == acsConfig.code_priorities.end())
-        return false;
-
-    for (auto& code : acsConfig.code_priorities[sys])
-    {
-        E_FType ft = code2Freq[sys][code];
-
-        if (ft1Ready == false)
-        {
-            ft1      = ft;
-            ft1Ready = true;
-            continue;
-        }
-
-        if (ft == ft1)
-            continue;
-
-        if (ft2Ready == false)
-        {
-            ft2      = ft;
-            ft2Ready = true;
-            continue;
-        }
-
-        if (ft == ft2)
-            continue;
-
-        {
-            ft3 = ft;
-            break;
-        }
-    }
-
-    return true;
-}
-
-/** Select observed frequency bands that are usable for slip detection.
- *
- * This helper is intentionally stricter than `satFreqs()`: it still honours
- * configured code priorities, but only returns frequency bands that are present
- * in the current observation, have a non-zero representative phase measurement,
- * and have a non-zero wavelength available in the satellite navigation data.
- *
- * This prevents GF/MW/PDE slip checks from evaluating assumed frequency bands
- * when an epoch is missing one of the configured signals.
- *
- * @param[in]  obs Observation to inspect.
- * @param[out] ft1 First observed usable frequency, or `NONE`.
- * @param[out] ft2 Second observed usable frequency, or `NONE`.
- * @param[out] ft3 Third observed usable frequency, or `NONE`.
- *
- * @return Number of usable observed frequencies written to the output
- *         parameters, from 0 to 3.
- */
-int obsFreqs(const GObs& obs, E_FType& ft1, E_FType& ft2, E_FType& ft3)
-{
-    ft1 = NONE;
-    ft2 = NONE;
-    ft3 = NONE;
-
-    E_Sys sys = obs.Sat.sys;
-    if (acsConfig.code_priorities.find(sys) == acsConfig.code_priorities.end())
-        return 0;
-
-    if (obs.satNav_ptr == nullptr)
-        return 0;
-
-    auto sysCodeIt = code2Freq.find(sys);
-    if (sysCodeIt == code2Freq.end())
-        return 0;
-
-    int count = 0;
-
-    for (auto& code : acsConfig.code_priorities[sys])
-    {
-        auto codeIt = sysCodeIt->second.find(code);
-        if (codeIt == sysCodeIt->second.end())
-            continue;
-
-        E_FType ft = codeIt->second;
-        if (ft == NONE || ft == ft1 || ft == ft2 || ft == ft3)
-            continue;
-
-        auto sigIt = obs.sigs.find(ft);
-        if (sigIt == obs.sigs.end() || sigIt->second.L == 0)
-            continue;
-
-        auto lamIt = obs.satNav_ptr->lamMap.find(ft);
-        if (lamIt == obs.satNav_ptr->lamMap.end() || lamIt->second == 0)
-            continue;
-
-        if (count == 0)
-        {
-            ft1 = ft;
-            count++;
-            continue;
-        }
-        if (count == 1)
-        {
-            ft2 = ft;
-            count++;
-            continue;
-        }
-        {
-            ft3 = ft;
-            count++;
-            break;
-        }
-    }
-
-    return count;
 }
 
 struct SlipNoise
@@ -1185,19 +1044,24 @@ void cycleslip3(
     if (nf < 3)
         return;
 
-    auto&  lam  = obs.satNav_ptr->lamMap;
-    double lam1 = lam[frq1];
-    double lam2 = lam[frq2];
-    double lam5 = lam[frq3];
+    auto& lam = obs.satNav_ptr->lamMap;
+
+    std::array<E_FType, 3> selectedFreqs = {frq1, frq2, frq3};
+    std::array<double, 3>  wavelengths   = {lam[frq1], lam[frq2], lam[frq3]};
+    std::array<std::pair<int, int>, 3> pairIndexes = {
+        std::pair<int, int>{0, 1},
+        std::pair<int, int>{0, 2},
+        std::pair<int, int>{1, 2}
+    };
 
     /* TD MW noise (m) */
-    double lamew = lam2 * lam5 / (lam5 - lam2);
-    if (lamew < 0)
-        lamew *= -1;
+    double lamExtraWide =
+        wavelengths[1] * wavelengths[2] / (wavelengths[2] - wavelengths[1]);
+    if (lamExtraWide < 0)
+        lamExtraWide *= -1;
 
-    E_FType   freqs[] = {frq1, frq2, frq3};
     SlipNoise noise;
-    if (!slipNoise(obs, freqs, 3, noise))
+    if (!slipNoise(obs, selectedFreqs.data(), 3, noise))
     {
         traceSlipEvent(trace, "PDE", obs, "skipped", frq1, frq2, frq3, 0, 0, 0, noise.reason);
         return;
@@ -1206,61 +1070,63 @@ void cycleslip3(
     double sigmaCode  = noise.sigmaCode;
     double sigmaPhase = noise.sigmaPhase;
 
-    double mwNoise12 = mwnoise(sigmaCode, sigmaPhase, lam1, lam2);
-    double mwNoise15 = mwnoise(sigmaCode, sigmaPhase, lam1, lam5);
-    double mwNoise25 = mwnoise(sigmaCode, sigmaPhase, lam2, lam5);
+    std::array<double, 3> mwNoises = {};
+    std::array<S_LC, 3>   lcNew    = {};
+    std::array<S_LC, 3>   lcPre    = {};
+    for (int i = 0; i < pairIndexes.size(); i++)
+    {
+        auto [freqA, freqB] = pairIndexes[i];
+
+        mwNoises[i] = mwnoise(sigmaCode, sigmaPhase, wavelengths[freqA], wavelengths[freqB]);
+        lcNew[i]    = getLC(lc, selectedFreqs[freqA], selectedFreqs[freqB]);
+        lcPre[i]    = getLC(satStat.lc_pre, selectedFreqs[freqA], selectedFreqs[freqB]);
+    }
 
     double sigmaGF = 2 * sigmaPhase; /* TD GF noise */
-
-    S_LC lc25new = getLC(lc, frq2, frq3);
-    S_LC lc25pre = getLC(satStat.lc_pre, frq2, frq3);
 
     /* averaged EMW measurement and noise */
     double fNew;
     // 	double sigmaEMW;
     if (acsConfig.preprocOpts.mw_proc_noise)
     {
-        fNew = lc25new.MW_c - satStat.emwSlip.mean;
+        fNew = lcNew[2].MW_c - satStat.emwSlip.mean;
     }
     else
     {
-        fNew = lc25new.MW_c - lc25pre.MW_c;
+        fNew = lcNew[2].MW_c - lcPre[2].MW_c;
     } /* Eq (13) in TN */
 
-    double deltaGF25 = lc25new.GF_Phas_m - lc25pre.GF_Phas_m;
+    double deltaGF23 = lcNew[2].GF_Phas_m - lcPre[2].GF_Phas_m;
 
     /* clock jump */
-    if (fabs(fNew * lamew) > 10e-3 * CLIGHT)
+    if (fabs(fNew * lamExtraWide) > 10e-3 * CLIGHT)
     {
         fprintf(stdout, "Potential clock jump rather than cycle slip -cs3\n");
         return;
     }
 
-    /* ionosphere coefficient for L2 & L5 */
-    double coef1 =
-        SQR(CLIGHT / lam1) / SQR(CLIGHT / lam5) - SQR(CLIGHT / lam1) / SQR(CLIGHT / lam2);
+    /* ionosphere coefficient for selected frequencies 2 and 3 */
+    double coef1 = SQR(CLIGHT / wavelengths[0]) / SQR(CLIGHT / wavelengths[2]) -
+                   SQR(CLIGHT / wavelengths[0]) / SQR(CLIGHT / wavelengths[1]);
     if (coef1 < 0)
         coef1 = -coef1;
 
-    S_LC lcNew = getLC(lc, frq1, frq2);
-    S_LC lcPre = getLC(satStat.lc_pre, frq1, frq2);
+    double lamw = wavelengths[0] * wavelengths[1] / (wavelengths[1] - wavelengths[0]);
 
-    double lamw = lam1 * lam2 / (lam2 - lam1);
-
-    double coef = SQR(lam2) / SQR(lam1) - 1;  // ionosphere coefficient for L1 & LX
+    double coef = SQR(wavelengths[1]) / SQR(wavelengths[0]) - 1;
 
     /* averaged MW measurement and noise */
     double fNw;
     if (acsConfig.preprocOpts.mw_proc_noise)
     {
-        fNw = lcNew.MW_c - satStat.mwSlip.mean;
+        fNw = lcNew[0].MW_c - satStat.mwSlip.mean;
     }
     else
     {
-        fNw = lcNew.MW_c - lcPre.MW_c;
+        fNw = lcNew[0].MW_c - lcPre[0].MW_c;
     } /* Eq (6) in TN */
 
-    double deltaGF = lcNew.GF_Phas_m - lcPre.GF_Phas_m;
+    double deltaGF = lcNew[0].GF_Phas_m - lcPre[0].GF_Phas_m;
 
     tracepdeex(
         2,
@@ -1273,8 +1139,8 @@ void cycleslip3(
         deltaGF,
         fNw,
         sigmaGF,
-        lamew,
-        deltaGF25,
+        lamExtraWide,
+        deltaGF23,
         fNew
     );
 
@@ -1438,21 +1304,21 @@ void detectslip(
         if (satStat.sigStatMap[ft2string(frq1)].slip.any == 0 &&
             satStat.sigStatMap[ft2string(frq2)].slip.any == 0)
         {
-            S_LC& lc12 = getLC(lc_new, frq1, frq2);
-            lowPassFilter(satStat.mwSlip, lc12.MW_c, acsConfig.preprocOpts.mw_proc_noise);
+            S_LC& lcPair12 = getLC(lc_new, frq1, frq2);
+            lowPassFilter(satStat.mwSlip, lcPair12.MW_c, acsConfig.preprocOpts.mw_proc_noise);
         }
         else
         {
             satStat.mwSlip = {};
         }
     }
-    /* track L5 again */
+    /* track selected third frequency again */
     else if (
         nf >= 3 && lc_new.L_m[frq1] != 0 && lc_new.L_m[frq2] != 0 && lc_new.L_m[frq3] != 0 &&
         lc_old.L_m[frq1] != 0 && lc_old.L_m[frq2] != 0 && lc_old.L_m[frq3] == 0
     )  // was zero, now not.
     {
-        /* set slip flag for L5 (introduce new ambiguity for L5) */
+        /* set slip flag for the selected third frequency and introduce a new ambiguity */
         satStat.sigStatMap[ft2string(frq3)].slip.retrack      = true;
         satStat.sigStatMap[ft2string(frq3)].savedSlip.retrack = true;
         traceSlipEvent(
@@ -1474,8 +1340,8 @@ void detectslip(
         if (satStat.sigStatMap[ft2string(frq1)].slip.any == 0 &&
             satStat.sigStatMap[ft2string(frq2)].slip.any == 0)
         {
-            S_LC& lc12 = getLC(lc_new, frq1, frq2);
-            lowPassFilter(satStat.mwSlip, lc12.MW_c, acsConfig.preprocOpts.mw_proc_noise);
+            S_LC& lcPair12 = getLC(lc_new, frq1, frq2);
+            lowPassFilter(satStat.mwSlip, lcPair12.MW_c, acsConfig.preprocOpts.mw_proc_noise);
         }
         else
         {
@@ -1514,13 +1380,13 @@ void detectslip(
             }
         }
 
-        /*update averaged MW25 noise when no cycle slip */
+        /* update averaged MW noise for selected frequencies 2 and 3 when no cycle slip */
         if (satStat.sigStatMap[ft2string(frq1)].slip.any == 0 &&
             satStat.sigStatMap[ft2string(frq2)].slip.any == 0 &&
             satStat.sigStatMap[ft2string(frq3)].slip.any == 0)
         {
-            S_LC& lc25 = getLC(lc_new, frq2, frq3);
-            lowPassFilter(satStat.emwSlip, lc25.MW_c, acsConfig.preprocOpts.mw_proc_noise);
+            S_LC& lcPair23 = getLC(lc_new, frq2, frq3);
+            lowPassFilter(satStat.emwSlip, lcPair23.MW_c, acsConfig.preprocOpts.mw_proc_noise);
         }
         else
         {
@@ -1639,8 +1505,8 @@ void detectslips(
         trace,
         "\nPDE-CS GPST       epoch                   prn  el   lamw    gf12    mw12     siggf  "
         "sigmw  "
-        "lamew     gf25    mw25   "
-        "            LC                   N1   N2   N5\n"
+        "lamew     gf23    mw23   "
+        "            LC                   N1   N2   N3\n"
     );
 
     for (auto& obs : only<GObs>(obsList))

--- a/src/cpp/common/acsQC.hpp
+++ b/src/cpp/common/acsQC.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "common/enums.h"
 #include "common/trace.hpp"
 
+struct GObs;
 struct ObsList;
 
 int lsqqc(
@@ -39,3 +41,5 @@ void detslp_gf(ObsList& obsList);
 void detslp_mw(ObsList& obsList);
 
 void detslp_ll(ObsList& obsList);
+
+int obsFreqs(const GObs& obs, E_FType& ft1, E_FType& ft2, E_FType& ft3);

--- a/src/cpp/common/ephBroadcast.cpp
+++ b/src/cpp/common/ephBroadcast.cpp
@@ -103,11 +103,7 @@ EPHTYPE* selSatEphFromMap(
 {
     //	trace(4,__FUNCTION__ " : time=%s sat=%2d iode=%d\n",time.to_string(3).c_str(),Sat,iode);
 
-    double tdelay = 0;
-    if (acsConfig.simulate_real_time)
-    {
-        tdelay = acsConfig.eph_time_delay[Sat.sys];
-    }
+    double tdelay = acsConfig.eph_time_delay[Sat.sys];
 
     double tmax;
     switch (Sat.sys)
@@ -132,12 +128,12 @@ EPHTYPE* selSatEphFromMap(
             break;
     }
 
-    if (tdelay > tmax)
+    if (tdelay < 0 || tdelay > tmax)
     {
         tracepdeex(
             2,
             trace,
-            "\nSet time delay is larger than time of Validity: tmax=%f, tdelay=%f  ",
+            "\nSet time delay is negative or larger than time of Validity: tmax=%f, tdelay=%f  ",
             tmax,
             tdelay
         );
@@ -145,27 +141,49 @@ EPHTYPE* selSatEphFromMap(
     }
 
     auto& satEphMap = ephMap[Sat][type];
-
-    auto it = satEphMap.lower_bound(time + tmax);
-    if (acsConfig.simulate_real_time  // Ephemeris should be no later than (time - tdelay) when
-                                      // simulating real-time
-        ||
-        iode < 0)  // Start with the last available ephemeris when iode not provided (== ANY_IODE)
+    if (satEphMap.empty())
     {
-        it = satEphMap.lower_bound(time - tdelay);
+        tracepdeex(
+            5,
+            trace,
+            "\nno broadcast ephemeris: sat=%s, type=%s",
+            Sat.id().c_str(),
+            enum_to_string(type)
+        );
+
+        return nullptr;
     }
+
+    // Start with the latest valid ephemeris (can be future ones for post-processing) and go back in
+    // time (forward in map)
+    auto it = satEphMap.lower_bound(time + tmax);
 
     while (it != satEphMap.end())
     {
         auto& [ephTime, eph] = *it;
 
-        if (fabs((eph.toe - time).to_double()) > tmax)
+        if (fabs((ephTime - time).to_double()) >
+            tmax)  // Don't use eph.toe as ephTime can be eph.t0 (for SBAS)
         {
+            // Too old, stop going further back to the past
             break;
         }
 
-        if (iode >= 0 && iode != eph.iode)  // Go one-way back in time (forward in map) from (time +
-                                            // tmax) when iode is provided (>= 0)
+        GTime lookupTime = ephTime;  // Try Looking up ephemeris with toe or t0
+        if (eph.ttm != GTime::noTime() && eph.ttm < ephTime)
+        {
+            // If the ephemeris is advanced, i.e. transmitted ahead of toe (ttm < toe), look up with
+            // transmission time instead - this allows to use the latest ephemeris in real-time
+            // processing
+            lookupTime = eph.ttm;
+        }
+        lookupTime += tdelay;  // Allow to wait some time before switching to next ephemeris when
+                               // IODE changes
+
+        if ((iode < 0 && time < lookupTime)  // When iode not provided (== ANY_IODE), search the
+                                             // latest available/transmitted ephemeris in the past
+            || (iode >= 0 && iode != eph.iode))  // Otherwise when iode is provided (>= 0), search
+                                                 // the matching ephemeris
         {
             it++;
             continue;

--- a/src/cpp/common/ephemeris.hpp
+++ b/src/cpp/common/ephemeris.hpp
@@ -169,6 +169,7 @@ struct Geph : BrdcEph
     double       taun;                       ///< SV clock bias (s)
     double       gammaN;                     ///< SV relative freq bias
     double       dtaun;                      ///< delay between L1 and L2 (s)
+    GTime        ttm;                        // unused, for templating only
 
     // original messages from stream/rinex for debugging
     double tofs;      ///< TOF (s) within the current day
@@ -234,6 +235,7 @@ struct Seph : BrdcEph
     double       af1  = 0;                   ///< satellite clock-drift (s/s)
     int          iode = -1;                  // unused, for templating only
     GTime        toe;                        // unused, for templating only
+    GTime        ttm;                        // unused, for templating only
 
     double tofs;                             ///< TOF (s) within the week
 };

--- a/src/cpp/common/linearCombo.cpp
+++ b/src/cpp/common/linearCombo.cpp
@@ -1,6 +1,7 @@
 // #pragma GCC optimize ("O0")
 
 #include "common/linearCombo.hpp"
+#include <array>
 #include "common/acsQC.hpp"
 #include "common/debug.hpp"
 #include "common/navigation.hpp"
@@ -192,15 +193,13 @@ void obs2lc(
     lc_t&  lcBase  ///< Linear combination base object to use
 )
 {
-    E_Sys sys = obs.Sat.sys;
-
     E_FType frq1;
     E_FType frq2;
     E_FType frq3;
 
-    bool pass = satFreqs(obs.Sat.sys, frq1, frq2, frq3);
+    int nf = obsFreqs(obs, frq1, frq2, frq3);
 
-    if (pass == false)
+    if (nf < 2)
         return;
 
     char strprefix[64];
@@ -214,126 +213,249 @@ void obs2lc(
 
     lcPrepareBase(obs, lcBase);
 
-    // iterate pairwise over the frequencies.
-    S_LC& lc12 = getLC(obs, lcBase, frq1, frq2);
-    S_LC& lc15 = getLC(obs, lcBase, frq1, frq3);
-    S_LC& lc25 = getLC(obs, lcBase, frq2, frq3);
+    // frq1/frq2/frq3 are priority-selected observed frequencies, not fixed L1/L2/L5.
+    std::array<S_LC*, 3> lcPairs = {
+        &getLC(obs, lcBase, frq1, frq2),
+        nullptr,
+        nullptr
+    };
+    if (nf >= 3)
+    {
+        lcPairs[1] = &getLC(obs, lcBase, frq1, frq3);
+        lcPairs[2] = &getLC(obs, lcBase, frq2, frq3);
+    }
 
     string frq1Str  = enum_to_string(frq1);
     string frq2Str  = enum_to_string(frq2);
-    string frq3Str  = enum_to_string(frq3);
+    string frq3Str  = (nf >= 3) ? enum_to_string(frq3) : "-";
     string frq12Str = frq1Str + frq2Str;
-    string frq13Str = frq1Str + frq3Str;
-    string frq23Str = frq2Str + frq3Str;
+    string frq13Str = (nf >= 3) ? frq1Str + frq3Str : "-";
+    string frq23Str = (nf >= 3) ? frq2Str + frq3Str : "-";
+    string sig1Str  = enum_to_string(obs.sigs[frq1].code);
+    string sig2Str  = enum_to_string(obs.sigs[frq2].code);
+    string sig3Str  = (nf >= 3) ? enum_to_string(obs.sigs[frq3].code) : "-";
 
-    tracepdeex(
-        3,
-        trace,
-        "%s zd L -- %-3s =%14.4f %-3s =%14.4f %-3s =%14.4f\n",
-        strprefix,
-        frq1Str.c_str(),
-        lcBase.L_m[frq1],
-        frq2Str.c_str(),
-        lcBase.L_m[frq2],
-        frq3Str.c_str(),
-        lcBase.L_m[frq3]
-    );
-    tracepdeex(
-        3,
-        trace,
-        "%s zd P -- %-3s =%14.4f %-3s =%14.4f %-3s =%14.4f\n",
-        strprefix,
-        frq1Str.c_str(),
-        lcBase.P[frq1],
-        frq2Str.c_str(),
-        lcBase.P[frq2],
-        frq3Str.c_str(),
-        lcBase.P[frq3]
-    );
-    tracepdeex(
-        3,
-        trace,
-        "%s mp P -- %-3s =%14.4f %-3s =%14.4f %-3s =%14.4f\n",
-        strprefix,
-        frq1Str.c_str(),
-        lcBase.mp[frq1],
-        frq2Str.c_str(),
-        lcBase.mp[frq2],
-        frq3Str.c_str(),
-        lcBase.mp[frq3]
-    );
-    tracepdeex(
-        3,
-        trace,
-        "%s gf L -- %-6s=%14.4f %-6s=%14.4f %-6s=%14.4f\n",
-        strprefix,
-        frq12Str.c_str(),
-        lc12.GF_Phas_m,
-        frq13Str.c_str(),
-        lc15.GF_Phas_m,
-        frq23Str.c_str(),
-        lc25.GF_Phas_m
-    );
-    tracepdeex(
-        3,
-        trace,
-        "%s gf P -- %-6s=%14.4f %-6s=%14.4f %-6s=%14.4f\n",
-        strprefix,
-        frq12Str.c_str(),
-        lc12.GF_Code_m,
-        frq13Str.c_str(),
-        lc15.GF_Code_m,
-        frq23Str.c_str(),
-        lc25.GF_Code_m
-    );
-    tracepdeex(
-        3,
-        trace,
-        "%s mw L -- %-6s=%14.4f %-6s=%14.4f %-6s=%14.4f\n",
-        strprefix,
-        frq12Str.c_str(),
-        lc12.MW_c,
-        frq13Str.c_str(),
-        lc15.MW_c,
-        frq23Str.c_str(),
-        lc25.MW_c
-    );
-    tracepdeex(
-        3,
-        trace,
-        "%s wl L -- %-6s=%14.4f %-6s=%14.4f %-6s=%14.4f\n",
-        strprefix,
-        frq12Str.c_str(),
-        lc12.WL_Phas_m,
-        frq13Str.c_str(),
-        lc15.WL_Phas_m,
-        frq23Str.c_str(),
-        lc25.WL_Phas_m
-    );
-    tracepdeex(
-        3,
-        trace,
-        "%s if L -- %-6s=%14.4f %-6s=%14.4f %-6s=%14.4f\n",
-        strprefix,
-        frq12Str.c_str(),
-        lc12.IF_Phas_m,
-        frq13Str.c_str(),
-        lc15.IF_Phas_m,
-        frq23Str.c_str(),
-        lc25.IF_Phas_m
-    );
-    tracepdeex(
-        3,
-        trace,
-        "%s if P -- %-6s=%14.4f %-6s=%14.4f %-6s=%14.4f\n",
-        strprefix,
-        frq12Str.c_str(),
-        lc12.IF_Code_m,
-        frq13Str.c_str(),
-        lc15.IF_Code_m,
-        frq23Str.c_str(),
-        lc25.IF_Code_m
-    );
+    if (nf >= 3)
+    {
+        tracepdeex(
+            3,
+            trace,
+            "%s selected signals -- %-3s = %-5s %-3s = %-5s %-3s = %-5s\n",
+            strprefix,
+            frq1Str.c_str(),
+            sig1Str.c_str(),
+            frq2Str.c_str(),
+            sig2Str.c_str(),
+            frq3Str.c_str(),
+            sig3Str.c_str()
+        );
+    }
+    else
+    {
+        tracepdeex(
+            3,
+            trace,
+            "%s selected signals -- %-3s = %-5s %-3s = %-5s\n",
+            strprefix,
+            frq1Str.c_str(),
+            sig1Str.c_str(),
+            frq2Str.c_str(),
+            sig2Str.c_str()
+        );
+    }
+
+    if (nf >= 3)
+    {
+        tracepdeex(
+            3,
+            trace,
+            "%s zd L -- %-3s =%14.4f %-3s =%14.4f %-3s =%14.4f\n",
+            strprefix,
+            frq1Str.c_str(),
+            lcBase.L_m[frq1],
+            frq2Str.c_str(),
+            lcBase.L_m[frq2],
+            frq3Str.c_str(),
+            lcBase.L_m[frq3]
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s zd P -- %-3s =%14.4f %-3s =%14.4f %-3s =%14.4f\n",
+            strprefix,
+            frq1Str.c_str(),
+            lcBase.P[frq1],
+            frq2Str.c_str(),
+            lcBase.P[frq2],
+            frq3Str.c_str(),
+            lcBase.P[frq3]
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s mp P -- %-3s =%14.4f %-3s =%14.4f %-3s =%14.4f\n",
+            strprefix,
+            frq1Str.c_str(),
+            lcBase.mp[frq1],
+            frq2Str.c_str(),
+            lcBase.mp[frq2],
+            frq3Str.c_str(),
+            lcBase.mp[frq3]
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s gf L -- %-6s=%14.4f %-6s=%14.4f %-6s=%14.4f\n",
+            strprefix,
+            frq12Str.c_str(),
+            lcPairs[0]->GF_Phas_m,
+            frq13Str.c_str(),
+            lcPairs[1]->GF_Phas_m,
+            frq23Str.c_str(),
+            lcPairs[2]->GF_Phas_m
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s gf P -- %-6s=%14.4f %-6s=%14.4f %-6s=%14.4f\n",
+            strprefix,
+            frq12Str.c_str(),
+            lcPairs[0]->GF_Code_m,
+            frq13Str.c_str(),
+            lcPairs[1]->GF_Code_m,
+            frq23Str.c_str(),
+            lcPairs[2]->GF_Code_m
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s mw L -- %-6s=%14.4f %-6s=%14.4f %-6s=%14.4f\n",
+            strprefix,
+            frq12Str.c_str(),
+            lcPairs[0]->MW_c,
+            frq13Str.c_str(),
+            lcPairs[1]->MW_c,
+            frq23Str.c_str(),
+            lcPairs[2]->MW_c
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s wl L -- %-6s=%14.4f %-6s=%14.4f %-6s=%14.4f\n",
+            strprefix,
+            frq12Str.c_str(),
+            lcPairs[0]->WL_Phas_m,
+            frq13Str.c_str(),
+            lcPairs[1]->WL_Phas_m,
+            frq23Str.c_str(),
+            lcPairs[2]->WL_Phas_m
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s if L -- %-6s=%14.4f %-6s=%14.4f %-6s=%14.4f\n",
+            strprefix,
+            frq12Str.c_str(),
+            lcPairs[0]->IF_Phas_m,
+            frq13Str.c_str(),
+            lcPairs[1]->IF_Phas_m,
+            frq23Str.c_str(),
+            lcPairs[2]->IF_Phas_m
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s if P -- %-6s=%14.4f %-6s=%14.4f %-6s=%14.4f\n",
+            strprefix,
+            frq12Str.c_str(),
+            lcPairs[0]->IF_Code_m,
+            frq13Str.c_str(),
+            lcPairs[1]->IF_Code_m,
+            frq23Str.c_str(),
+            lcPairs[2]->IF_Code_m
+        );
+    }
+    else
+    {
+        tracepdeex(
+            3,
+            trace,
+            "%s zd L -- %-3s =%14.4f %-3s =%14.4f\n",
+            strprefix,
+            frq1Str.c_str(),
+            lcBase.L_m[frq1],
+            frq2Str.c_str(),
+            lcBase.L_m[frq2]
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s zd P -- %-3s =%14.4f %-3s =%14.4f\n",
+            strprefix,
+            frq1Str.c_str(),
+            lcBase.P[frq1],
+            frq2Str.c_str(),
+            lcBase.P[frq2]
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s mp P -- %-3s =%14.4f %-3s =%14.4f\n",
+            strprefix,
+            frq1Str.c_str(),
+            lcBase.mp[frq1],
+            frq2Str.c_str(),
+            lcBase.mp[frq2]
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s gf L -- %-6s=%14.4f\n",
+            strprefix,
+            frq12Str.c_str(),
+            lcPairs[0]->GF_Phas_m
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s gf P -- %-6s=%14.4f\n",
+            strprefix,
+            frq12Str.c_str(),
+            lcPairs[0]->GF_Code_m
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s mw L -- %-6s=%14.4f\n",
+            strprefix,
+            frq12Str.c_str(),
+            lcPairs[0]->MW_c
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s wl L -- %-6s=%14.4f\n",
+            strprefix,
+            frq12Str.c_str(),
+            lcPairs[0]->WL_Phas_m
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s if L -- %-6s=%14.4f\n",
+            strprefix,
+            frq12Str.c_str(),
+            lcPairs[0]->IF_Phas_m
+        );
+        tracepdeex(
+            3,
+            trace,
+            "%s if P -- %-6s=%14.4f\n",
+            strprefix,
+            frq12Str.c_str(),
+            lcPairs[0]->IF_Code_m
+        );
+    }
 
     traceJson(
         5,

--- a/src/cpp/common/preprocessorFreqs.cpp
+++ b/src/cpp/common/preprocessorFreqs.cpp
@@ -1,0 +1,130 @@
+#include "common/acsQC.hpp"
+#include "common/acsConfig.hpp"
+#include "common/common.hpp"
+#include "common/constants.hpp"
+#include "common/navigation.hpp"
+#include "common/observations.hpp"
+
+/** Select up to three configured frequency bands for a satellite system.
+ *
+ * This is the legacy frequency selector used by several modelling paths outside
+ * slip detection. It follows `acsConfig.code_priorities[sys]` and converts the
+ * first unique codes into frequency bands, but it does not inspect a particular
+ * observation to confirm that measurements are present.
+ *
+ * The outputs retain historical defaults (`F1`, `F2`, `F5`) when priorities are
+ * incomplete. Do not use this helper when the algorithm must know which
+ * frequencies are actually observed at the current epoch; use `obsFreqs()` for
+ * slip detection.
+ */
+bool satFreqs(E_Sys sys, E_FType& ft1, E_FType& ft2, E_FType& ft3)
+{
+    bool ft1Ready = false;
+    bool ft2Ready = false;
+
+    ft1 = F1;
+    ft2 = F2;
+    ft3 = F5;
+
+    if (acsConfig.code_priorities.find(sys) == acsConfig.code_priorities.end())
+        return false;
+
+    for (auto& code : acsConfig.code_priorities[sys])
+    {
+        E_FType ft = code2Freq[sys][code];
+
+        if (ft1Ready == false)
+        {
+            ft1      = ft;
+            ft1Ready = true;
+            continue;
+        }
+
+        if (ft == ft1)
+            continue;
+
+        if (ft2Ready == false)
+        {
+            ft2      = ft;
+            ft2Ready = true;
+            continue;
+        }
+
+        if (ft == ft2)
+            continue;
+
+        ft3 = ft;
+        break;
+    }
+
+    return true;
+}
+
+/** Select observed frequency bands that are usable for slip detection.
+ *
+ * This helper is intentionally stricter than `satFreqs()`: it still honours
+ * configured code priorities, but only returns frequency bands that are present
+ * in the current observation, have a non-zero representative phase measurement,
+ * and have a non-zero wavelength available in the satellite navigation data.
+ *
+ * The selector returns the first three distinct usable frequencies only. Extra
+ * usable frequencies later in `code_priorities` are left for future 4+
+ * frequency processing rather than silently changing the current dual/triple
+ * frequency slip-detection model.
+ */
+int obsFreqs(const GObs& obs, E_FType& ft1, E_FType& ft2, E_FType& ft3)
+{
+    ft1 = NONE;
+    ft2 = NONE;
+    ft3 = NONE;
+
+    E_Sys sys = obs.Sat.sys;
+    if (acsConfig.code_priorities.find(sys) == acsConfig.code_priorities.end())
+        return 0;
+
+    if (obs.satNav_ptr == nullptr)
+        return 0;
+
+    auto sysCodeIt = code2Freq.find(sys);
+    if (sysCodeIt == code2Freq.end())
+        return 0;
+
+    int count = 0;
+
+    for (auto& code : acsConfig.code_priorities[sys])
+    {
+        auto codeIt = sysCodeIt->second.find(code);
+        if (codeIt == sysCodeIt->second.end())
+            continue;
+
+        E_FType ft = codeIt->second;
+        if (ft == NONE || ft == ft1 || ft == ft2 || ft == ft3)
+            continue;
+
+        auto sigIt = obs.sigs.find(ft);
+        if (sigIt == obs.sigs.end() || sigIt->second.L == 0)
+            continue;
+
+        auto lamIt = obs.satNav_ptr->lamMap.find(ft);
+        if (lamIt == obs.satNav_ptr->lamMap.end() || lamIt->second == 0)
+            continue;
+
+        if (count == 0)
+        {
+            ft1 = ft;
+            count++;
+            continue;
+        }
+        if (count == 1)
+        {
+            ft2 = ft;
+            count++;
+            continue;
+        }
+
+        ft3 = ft;
+        return 3;
+    }
+
+    return count;
+}

--- a/src/cpp/common/rinex.cpp
+++ b/src/cpp/common/rinex.cpp
@@ -878,7 +878,7 @@ int decodeObsEpoch(
         if (flag >= 3 && flag <= 5)
             return n;
 
-        if (buff[0] != '>' || str2time(buff, 2, 29, time, tsys))
+        if (buff[0] != '>' || str2time(buff, 2, 27, time, tsys))
         {
             BOOST_LOG_TRIVIAL(debug) << "rinex obs invalid epoch: epoch=" << buff;
             return 0;

--- a/src/cpp/common/rtcmDecoder.cpp
+++ b/src/cpp/common/rtcmDecoder.cpp
@@ -783,8 +783,10 @@ void RtcmDecoder::decodeEphemeris(vector<unsigned char>& data)  ///< stream data
         RTod tofs = geph.tk_hour * 60 * 60 + geph.tk_min * 60 + geph.tk_sec;
 
         GTime nearTime = rtcmTime();
-        geph.toe       = GTime(toes, nearTime);
-        geph.tof       = GTime(tofs, nearTime);
+
+        geph.ttm = nearTime;
+        geph.toe = GTime(toes, nearTime);
+        geph.tof = GTime(tofs, nearTime);
     }
     else if (sys == E_Sys::BDS)
     {

--- a/src/cpp/common/sanityCheckers/EphemerisTimeDelayChecker.cpp
+++ b/src/cpp/common/sanityCheckers/EphemerisTimeDelayChecker.cpp
@@ -3,17 +3,32 @@
 
 bool EphemerisTimeDelayChecker::check(ACSConfig& config)
 {
-    if (config.simulate_real_time)
+    if (config.netOpts.uploadingStreamData.empty())
     {
         return true;
     }
 
-    for (E_Sys sys : magic_enum::enum_values<E_Sys>())
+    bool pass = true;
+
+    for (auto [sys, proc] : config.process_sys)
     {
-        config.eph_time_delay[sys] = config.default_eph_time_delay[sys];
+        if (proc == false)
+            continue;
+
+        double time_delay = config.eph_time_delay[sys];
+
+        if (time_delay < 30)
+        {
+            BOOST_LOG_TRIVIAL(warning)
+                << "`sys_options:" << enum_to_string(sys) << ":eph_time_delay` is set to "
+                << time_delay
+                << ". A value of at least 30 seconds is recommended for uploading SSR streams";
+
+            pass = false;
+        }
     }
 
-    return true;
+    return pass;
 }
 
 std::string EphemerisTimeDelayChecker::name() const

--- a/src/cpp/pea/preprocessor.cpp
+++ b/src/cpp/pea/preprocessor.cpp
@@ -94,6 +94,7 @@ struct ObservationRecord
     E_ObsCode   code;
     double      P      = 0;
     double      L      = 0;
+    double      D      = 0;
     double      snr    = 0;
     double      el_deg = 0;
     double      az_deg = 0;
@@ -113,9 +114,10 @@ void obsRec(Trace& trace, Trace& jsonTrace, const ObservationRecord& rec)
     bool hasSnr =
         (rec.status == E_ObsStatus::OBSERVED || rec.status == E_ObsStatus::CODE_ONLY ||
          rec.status == E_ObsStatus::PHASE_ONLY);
+    bool hasDoppler = (rec.D != 0);
 
     // Format values as strings (without width specifiers - will be applied in tracepdeex format)
-    char pStr[32], lStr[32], sStr[32];
+    char pStr[32], lStr[32], dStr[32], sStr[32];
     if (hasCode)
         snprintf(pStr, sizeof(pStr), "%.6f", rec.P);
     else
@@ -126,6 +128,11 @@ void obsRec(Trace& trace, Trace& jsonTrace, const ObservationRecord& rec)
     else
         snprintf(lStr, sizeof(lStr), "%s", "NaN");
 
+    if (hasDoppler)
+        snprintf(dStr, sizeof(dStr), "%.6f", rec.D);
+    else
+        snprintf(dStr, sizeof(dStr), "%s", "NaN");
+
     if (hasSnr)
         snprintf(sStr, sizeof(sStr), "%.2f", rec.snr);
     else
@@ -134,7 +141,7 @@ void obsRec(Trace& trace, Trace& jsonTrace, const ObservationRecord& rec)
     tracepdeex(
         0,
         trace,
-        "\n%s: epoch= %s sat= %5s sig= %5s P= %16s L= %16s S= %8s el= %6.2f az= %6.2f block= %12s "
+        "\n%s: epoch= %s sat= %5s sig= %5s P= %16s L= %16s D= %16s S= %8s el= %6.2f az= %6.2f block= %12s "
         "status= %s",
         __FUNCTION__,
         rec.time.to_string().c_str(),
@@ -142,6 +149,7 @@ void obsRec(Trace& trace, Trace& jsonTrace, const ObservationRecord& rec)
         enum_to_string(rec.code).c_str(),
         pStr,
         lStr,
+        dStr,
         sStr,
         rec.el_deg,
         rec.az_deg,
@@ -161,7 +169,7 @@ void obsRec(Trace& trace, Trace& jsonTrace, const ObservationRecord& rec)
         {{"SNR", hasSnr ? rec.snr : std::nan("")},
          {"L", hasPhase ? rec.L : std::nan("")},
          {"P", hasCode ? rec.P : std::nan("")},
-         {"D", 0.0},  // Not stored in record currently
+         {"D", hasDoppler ? rec.D : std::nan("")},
          {"el", rec.el_deg},
          {"az", rec.az_deg},
          {"blockType", rec.blockType},
@@ -202,6 +210,7 @@ void classifySignals(
             rec.code   = sig.code;
             rec.P      = sig.P;
             rec.L      = sig.L;
+            rec.D      = sig.D;
             rec.snr    = sig.snr;
             rec.el_deg = el_deg;
             rec.az_deg = az_deg;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -56,6 +56,17 @@ add_executable(trace_file_cache_tests
     unit/test_TraceFileCache.cpp
 )
 
+add_executable(preprocessor_frequency_tests
+    ../cpp/common/constants.cpp
+    ../cpp/common/preprocessorFreqs.cpp
+    unit/test_PreprocessorFreqs.cpp
+)
+
+add_executable(rinex_epoch_tests
+    ../cpp/common/gTime.cpp
+    unit/test_RinexEpoch.cpp
+)
+
 add_sanity_checker_test(config_sanity_manager_tests
     unit/sanityCheckers/test_ConfigSanityManager.cpp
 )
@@ -81,6 +92,8 @@ add_sanity_checker_test(sbas_sanity_checker_tests
 add_custom_target(unit_tests
     DEPENDS receiver_metadata_tests
             trace_file_cache_tests
+            preprocessor_frequency_tests
+            rinex_epoch_tests
             config_sanity_manager_tests
             epoch_tolerance_checker_tests
             ephemeris_time_delay_checker_tests
@@ -99,9 +112,23 @@ target_link_libraries(trace_file_cache_tests PRIVATE
     Boost::unit_test_framework
 )
 
+target_link_libraries(preprocessor_frequency_tests PRIVATE
+    Boost::program_options
+    Boost::unit_test_framework
+)
+
+target_link_libraries(rinex_epoch_tests PRIVATE
+    Boost::log
+    Boost::log_setup
+    Boost::program_options
+    Boost::unit_test_framework
+)
+
 if(WIN32)
     target_link_libraries(receiver_metadata_tests PRIVATE ws2_32 wsock32)
 endif()
 
 configure_unit_test(receiver_metadata_tests)
 configure_unit_test(trace_file_cache_tests)
+configure_unit_test(preprocessor_frequency_tests)
+configure_unit_test(rinex_epoch_tests)

--- a/src/tests/unit/sanityCheckers/test_EphemerisTimeDelayChecker.cpp
+++ b/src/tests/unit/sanityCheckers/test_EphemerisTimeDelayChecker.cpp
@@ -3,44 +3,63 @@
 #include "common/acsConfig.hpp"
 #include "common/sanityCheckers/EphemerisTimeDelayChecker.hpp"
 
-BOOST_AUTO_TEST_CASE(resets_ephemeris_time_delay_outside_real_time)
+BOOST_AUTO_TEST_CASE(returns_false_to_warn_when_eph_time_delay_is_below_30_for_any_uploading_stream)
 {
     ACSConfig config;
-    config.simulate_real_time = false;
+    config.netOpts.uploadingStreamData["TEST"].rtcmMsgOptsMap[RtcmMessageType::GPS_SSR_COMB_CORR] =
+        RtcmMsgTypeOpts();
+    config.netOpts.uploadingStreamData["TEST"].rtcmMsgOptsMap[RtcmMessageType::GLO_SSR_COMB_CORR] =
+        RtcmMsgTypeOpts();
+    config.netOpts.uploadingStreamData["TEST"].rtcmMsgOptsMap[RtcmMessageType::GAL_SSR_COMB_CORR] =
+        RtcmMsgTypeOpts();
+    config.process_sys[E_Sys::GPS] = true;
+    config.process_sys[E_Sys::GLO] = true;
+    config.process_sys[E_Sys::GAL] = true;
 
     for (E_Sys sys : magic_enum::enum_values<E_Sys>())
     {
-        config.default_eph_time_delay[sys] = 12.5;
-        config.eph_time_delay[sys]         = 99.0;
+        config.eph_time_delay[sys] = 20.0;
     }
 
     EphemerisTimeDelayChecker checker;
 
-    BOOST_CHECK(checker.check(config));
-
-    for (E_Sys sys : magic_enum::enum_values<E_Sys>())
-    {
-        BOOST_CHECK_EQUAL(config.eph_time_delay[sys], config.default_eph_time_delay[sys]);
-    }
+    BOOST_CHECK(!checker.check(config));
 }
 
-BOOST_AUTO_TEST_CASE(does_not_reset_ephemeris_time_delay_in_real_time)
+BOOST_AUTO_TEST_CASE(passes_when_eph_time_delay_is_at_least_30_for_all_uploading_streams)
 {
     ACSConfig config;
-    config.simulate_real_time = true;
+    config.netOpts.uploadingStreamData["TEST"].rtcmMsgOptsMap[RtcmMessageType::GPS_SSR_COMB_CORR] =
+        RtcmMsgTypeOpts();
+    config.netOpts.uploadingStreamData["TEST"].rtcmMsgOptsMap[RtcmMessageType::GLO_SSR_COMB_CORR] =
+        RtcmMsgTypeOpts();
+    config.netOpts.uploadingStreamData["TEST"].rtcmMsgOptsMap[RtcmMessageType::GAL_SSR_COMB_CORR] =
+        RtcmMsgTypeOpts();
+    config.process_sys[E_Sys::GPS] = true;
+    config.process_sys[E_Sys::GLO] = true;
+    config.process_sys[E_Sys::GAL] = true;
 
     for (E_Sys sys : magic_enum::enum_values<E_Sys>())
     {
-        config.default_eph_time_delay[sys] = 12.5;
-        config.eph_time_delay[sys]         = 99.0;
+        config.eph_time_delay[sys] = 30.0;
     }
 
     EphemerisTimeDelayChecker checker;
 
     BOOST_CHECK(checker.check(config));
+}
+
+BOOST_AUTO_TEST_CASE(is_noop_when_there_is_no_uploading_stream)
+{
+    ACSConfig config;
+    config.netOpts.uploadingStreamData.clear();
 
     for (E_Sys sys : magic_enum::enum_values<E_Sys>())
     {
-        BOOST_CHECK_EQUAL(config.eph_time_delay[sys], 99.0);
+        config.eph_time_delay[sys] = 10.0;
     }
+
+    EphemerisTimeDelayChecker checker;
+
+    BOOST_CHECK(checker.check(config));
 }

--- a/src/tests/unit/test_PreprocessorFreqs.cpp
+++ b/src/tests/unit/test_PreprocessorFreqs.cpp
@@ -1,0 +1,110 @@
+#define BOOST_TEST_MODULE preprocessor_frequency_tests
+#include <boost/test/unit_test.hpp>
+
+#include "common/acsConfig.hpp"
+#include "common/acsQC.hpp"
+#include "common/navigation.hpp"
+#include "common/observations.hpp"
+
+ACSConfig acsConfig = {};
+
+namespace
+{
+GObs makeGalObs(std::initializer_list<E_FType> freqs)
+{
+    GObs obs;
+    obs.Sat = SatSys(E_Sys::GAL, 1);
+
+    auto satNav = std::make_unique<SatNav>();
+    for (auto freq : freqs)
+    {
+        Sig sig;
+        sig.L          = 1;
+        obs.sigs[freq] = sig;
+        satNav->lamMap[freq] = 1;
+    }
+
+    obs.satNav_ptr = satNav.release();
+    return obs;
+}
+
+void releaseNav(GObs& obs)
+{
+    delete obs.satNav_ptr;
+    obs.satNav_ptr = nullptr;
+}
+}  // namespace
+
+BOOST_AUTO_TEST_CASE(obs_freqs_keeps_first_three_usable_priority_frequencies)
+{
+    acsConfig.code_priorities.clear();
+    acsConfig.code_priorities[E_Sys::GAL] = {
+        E_ObsCode::L1C,
+        E_ObsCode::L5Q,
+        E_ObsCode::L6C,
+        E_ObsCode::L7Q
+    };
+
+    auto obs = makeGalObs({F1, F5, F6, F7});
+
+    E_FType ft1;
+    E_FType ft2;
+    E_FType ft3;
+    int     nf = obsFreqs(obs, ft1, ft2, ft3);
+
+    BOOST_CHECK_EQUAL(nf, 3);
+    BOOST_CHECK_EQUAL(ft1, F1);
+    BOOST_CHECK_EQUAL(ft2, F5);
+    BOOST_CHECK_EQUAL(ft3, F6);
+
+    releaseNav(obs);
+}
+
+BOOST_AUTO_TEST_CASE(obs_freqs_uses_l6_when_earlier_priority_frequency_is_missing)
+{
+    acsConfig.code_priorities.clear();
+    acsConfig.code_priorities[E_Sys::GAL] = {
+        E_ObsCode::L1C,
+        E_ObsCode::L5Q,
+        E_ObsCode::L6C,
+        E_ObsCode::L7Q
+    };
+
+    auto obs = makeGalObs({F1, F6, F7});
+
+    E_FType ft1;
+    E_FType ft2;
+    E_FType ft3;
+    int     nf = obsFreqs(obs, ft1, ft2, ft3);
+
+    BOOST_CHECK_EQUAL(nf, 3);
+    BOOST_CHECK_EQUAL(ft1, F1);
+    BOOST_CHECK_EQUAL(ft2, F6);
+    BOOST_CHECK_EQUAL(ft3, F7);
+
+    releaseNav(obs);
+}
+
+BOOST_AUTO_TEST_CASE(obs_freqs_honours_l6_before_l5_priority)
+{
+    acsConfig.code_priorities.clear();
+    acsConfig.code_priorities[E_Sys::GAL] = {
+        E_ObsCode::L1C,
+        E_ObsCode::L6C,
+        E_ObsCode::L5Q
+    };
+
+    auto obs = makeGalObs({F1, F5, F6});
+
+    E_FType ft1;
+    E_FType ft2;
+    E_FType ft3;
+    int     nf = obsFreqs(obs, ft1, ft2, ft3);
+
+    BOOST_CHECK_EQUAL(nf, 3);
+    BOOST_CHECK_EQUAL(ft1, F1);
+    BOOST_CHECK_EQUAL(ft2, F6);
+    BOOST_CHECK_EQUAL(ft3, F5);
+
+    releaseNav(obs);
+}

--- a/src/tests/unit/test_RinexEpoch.cpp
+++ b/src/tests/unit/test_RinexEpoch.cpp
@@ -1,0 +1,26 @@
+#define BOOST_TEST_MODULE rinex_epoch_tests
+#include <boost/test/unit_test.hpp>
+
+#include "common/acsConfig.hpp"
+#include "common/gTime.hpp"
+#include "common/navigation.hpp"
+
+ACSConfig  acsConfig = {};
+Navigation nav       = {};
+GTime      tsync     = {};
+
+BOOST_AUTO_TEST_CASE(rinex3_epoch_time_uses_columns_3_through_29)
+{
+    const char epoch[] = "> 2024 01 02 03 04  5.1234567  0 12";
+
+    GTime time;
+    BOOST_REQUIRE_EQUAL(str2time(epoch, 2, 27, time, E_TimeSys::GPST), 0);
+
+    const GEpoch parsed = time;
+    BOOST_CHECK_EQUAL(parsed.year, 2024);
+    BOOST_CHECK_EQUAL(parsed.month, 1);
+    BOOST_CHECK_EQUAL(parsed.day, 2);
+    BOOST_CHECK_EQUAL(parsed.hour, 3);
+    BOOST_CHECK_EQUAL(parsed.min, 4);
+    BOOST_CHECK_SMALL(parsed.sec - 5.1234567, 1e-7);
+}


### PR DESCRIPTION

# Release 4.1.3

## Added

Ginan core:
- Added configurable preprocessor frequency selection, allowing more flexible code/frequency priorities in preprocessing workflows.
- Added a Doppler placeholder path in the preprocessor to support upcoming Doppler-based preprocessing work.

## Changed

Ginan core:
- Updated broadcast ephemeris IODE selection to support use of the latest suitable ephemeris/IODE in real-time processing.
- Added a safeguard to wait at least 30 seconds before changing IODE when uploading SSR streams.

## Fixed

Ginan core:
- Fixed RINEX time parsing when `str2time` reads overflowing fixed-width fields.